### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build client
+        env:
+          VITE_BASE_PATH: /${{ github.event.repository.name }}/
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: client/build/client
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/client/app/routes/footer/Footer.tsx
+++ b/client/app/routes/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import Style from "./Footer.module.scss";
+import Style from "./footer.module.scss";
 import FooterMain from "./footerMain/footerMain";
 
 export default function Footer() {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,5 +4,6 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? "/",
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
 });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the client and deploys it to GitHub Pages
- configure the Vite build to respect the GitHub Pages base path
- fix the footer stylesheet import so the production build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f6781a38832cabee109655d6d816